### PR TITLE
[fix] tts 텍스트 데이터가 중복해서 생기는 버그해결 #296

### DIFF
--- a/src/api/uploadTTSProjectData.ts
+++ b/src/api/uploadTTSProjectData.ts
@@ -1,6 +1,6 @@
 import { TTSDetailDto, TTSSaveDto } from '@/api/aIParkAPI.schemas';
 import { saveTTSProject } from '@/api/ttsAPI';
-import { TTSItem } from '@/stores/tts.store';
+import { initialProjectData, TTSItem } from '@/stores/tts.store';
 
 type setProjectData = (data: {
   projectId: number | null;
@@ -16,7 +16,8 @@ type setProjectData = (data: {
 export const uploadTTSProjectData = async (
   projectData: TTSSaveDto,
   items: TTSItem[],
-  setProjectData: setProjectData
+  setProjectData: setProjectData,
+  setItems: (items: TTSItem[]) => void
 ) => {
   try {
     const transformedData = {
@@ -46,6 +47,18 @@ export const uploadTTSProjectData = async (
         globalVoiceStyleId: response.ttsProject.globalVoiceStyleId,
         ttsDetails: response.ttsDetails,
       });
+      setItems(
+        response.ttsDetails.map((detail: TTSDetailDto, index: number) => ({
+          id: String(detail.id),
+          enitityId: detail.id,
+          text: items[index].text || initialProjectData.fullScript,
+          isSelected: items[index].isSelected || false,
+          speed: items[index].speed || initialProjectData.globalSpeed,
+          volume: items[index].volume || initialProjectData.globalVolume,
+          pitch: items[index].pitch || initialProjectData.globalPitch,
+          style: items[index].style || String(initialProjectData.globalVoiceStyleId),
+        }))
+      );
     }
 
     return response;

--- a/src/pages/TTSPage.tsx
+++ b/src/pages/TTSPage.tsx
@@ -102,7 +102,8 @@ const TTSPage = () => {
     const loadTTSProject = async () => {
       if (!id) {
         console.warn('ID가 없습니다.');
-        showAlert('저장을 누르면 새 프로젝트가 저장됩니다.', 'default');
+        // showAlert('저장을 누르면 새 프로젝트가 저장됩니다.', 'default');
+        setProjectData(initialProjectData);
         setItems([]);
         setHistoryItems([]);
         return;
@@ -172,7 +173,6 @@ const TTSPage = () => {
       value !== null && value !== undefined;
 
     const validations = [
-      { condition: !projectData.projectId, message: '프로젝트를 먼저 저장을 해주세요' },
       {
         condition: !projectData.projectName || !items.length,
         message: '프로젝트 이름 또는 항목이 없습니다.',
@@ -222,7 +222,7 @@ const TTSPage = () => {
     }
 
     try {
-      await uploadTTSProjectData(projectData, items, setProjectData);
+      await uploadTTSProjectData(projectData, items, setProjectData, setItems);
     } catch (error) {
       console.error('프로젝트 저장 오류:', error);
       showAlert('프로젝트 저장 중 오류가 발생했습니다.', 'destructive');
@@ -261,7 +261,15 @@ const TTSPage = () => {
     } finally {
       setIsGenerating(false);
     }
-  }, [projectData, items, setHistoryItems, setProjectData, checkIsValidToGenerate, showAlert]);
+  }, [
+    projectData,
+    items,
+    setHistoryItems,
+    setProjectData,
+    checkIsValidToGenerate,
+    showAlert,
+    setItems,
+  ]);
 
   const historyItems = useTTSAudioHistoryStore((state) => state.historyItems);
   const lastAudioUrl =
@@ -272,7 +280,7 @@ const TTSPage = () => {
 
   const handleSave = useCallback(async () => {
     try {
-      const response = await uploadTTSProjectData(projectData, items, setProjectData);
+      const response = await uploadTTSProjectData(projectData, items, setProjectData, setItems);
       // 새 프로젝트인 경우 URL 업데이트
       if (!projectData.projectId && response?.ttsProject?.id) {
         window.history.replaceState(null, '', `/tts/${response.ttsProject.id}`);
@@ -282,7 +290,8 @@ const TTSPage = () => {
       console.error('프로젝트 저장 오류:', error);
       showAlert('프로젝트 저장에 실패했습니다.', 'destructive');
     }
-  }, [projectData, items, setProjectData, showAlert]);
+  }, [projectData, items, setProjectData, showAlert, setItems]);
+  console.log('items', items);
 
   return (
     <PageLayout


### PR DESCRIPTION
- tts 텍스트 데이터가 중복해서 들어가는 버그를 해결
- 원인은 save한다음 tts의 아이템들이 null이 되는 오류 때문에 일어난 일
- 이전 프로젝트 데이터가 들어가는 버그 해결
- src/api/uploadTTSProjectData.ts 파일이 수정
- src/pages/TTSPage.tsx 파일이 수정
